### PR TITLE
Rework topic bars to css-grid using action objects

### DIFF
--- a/all/views/forum.twig
+++ b/all/views/forum.twig
@@ -68,10 +68,10 @@
 					</span>
 				</div>
 				<div class="o-bar-right">
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+					<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
 						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
 					</a>
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
+					<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
 						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
 					</a>
 				</div>
@@ -94,40 +94,13 @@
 					</span>
 				</div>
 				<div class="o-bar-right">
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+					<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
 						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
 					</a>
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
+					<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
 						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
 					</a>
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.filter }}">
-						{{ 'mdi:filter-variant'|icon('iconify', 'o-icon')|safe }}
-						<div class="c-menu-container t-menu-container" data-container="menu">
-							<ul class="c-menu t-menu">
-								{% for item in filters %}
-								<li class="c-menu-item t-menu-item">
-									<a class="c-menu-link t-menu-link" href="#">{{ item }}</a>
-								</li>
-								{% endfor %}
-							</ul>
-						</div>
-					</a>
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.sort }}">
-						{{ 'mdi:sort'|icon('iconify', 'o-icon')|safe }}
-						<div class="c-menu-container t-menu-container" data-container="menu">
-							<ul class="c-menu t-menu">
-								{% for item in sorts %}
-								<li class="c-menu-item t-menu-item">
-									<a class="c-menu-link t-menu-link" href="#">{{ item }}</a>
-								</li>
-								{% endfor %}
-							</ul>
-						</div>
-					</a>
-					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.order }}">
-						{{ 'mdi:sort-ascending'|icon('iconify', 'o-icon')|safe }}
-					</a>
-					<span class="o-bar-info">
+					<span class="o-bar-info c-topic-total t-topic-total">
 						{{ 'mdi:file-outline'|icon('iconify', 'o-icon o-bar-info-icon')|safe }}
 						<span class="o-bar-item-text">{{ topics|length }}</span>
 					</span>

--- a/all/views/forum.twig
+++ b/all/views/forum.twig
@@ -30,18 +30,19 @@
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
 			<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
-				<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
+				<div class="o-bar-left c-topic-header-left t-topic-header-left">
+					<span class="o-bar-item c-topic-header-item t-topic-header-item">
 						<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">{{ lang.subforums }}</h2>
-					</li>
-				</ul>
-				<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
-							{{ 'mdi:chevron-up'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-				</ul>
+					</span>
+				</div>
+				<div class="o-bar-right c-topic-header-right t-topic-header-right">
+					<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
+					</a>
+					<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
+						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
+					</a>
+				</div>
 			</div>
 			<ul class="o-list c-topic t-topic" role="rowgroup" data-container="collapse">
 				{% for item in forums %}
@@ -61,18 +62,18 @@
 	{# Announcements #}
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
-			<div class="o-bar" data-toggle-parent="collapse">
-				<div class="o-bar-left">
-					<span class="o-bar-item">
-						<h2 class="o-bar-title" role="heading" aria-level="3">{{ lang.announcements }}</h2>
+			<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
+				<div class="o-bar-left c-topic-header-left t-topic-header-left">
+					<span class="o-bar-item c-topic-header-item t-topic-header-item">
+						<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">{{ lang.announcements }}</h2>
 					</span>
 				</div>
-				<div class="o-bar-right">
-					<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
-						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
+				<div class="o-bar-right c-topic-header-right t-topic-header-right">
+					<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
 					</a>
-					<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
-						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
+					<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
+						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
 					</a>
 				</div>
 			</div>
@@ -87,18 +88,18 @@
 	{# Main Topic List #}
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
-			<div class="o-bar" data-toggle-parent="collapse">
-				<div class="o-bar-left">
-					<span class="o-bar-item">
-						<h2 class="o-bar-title" role="heading" aria-level="3">{{ lang.topics }}</h2>
+			<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
+				<div class="o-bar-left c-topic-header-left t-topic-header-left">
+					<span class="o-bar-item c-topic-header-item t-topic-header-item">
+						<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">{{ lang.topics }}</h2>
 					</span>
 				</div>
-				<div class="o-bar-right">
-					<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
-						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
+				<div class="o-bar-right c-topic-header-right t-topic-header-right">
+					<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
 					</a>
-					<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
-						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
+					<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="{{ lang.mark }}">
+						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
 					</a>
 					<span class="o-bar-info c-topic-total t-topic-total">
 						{{ 'mdi:file-outline'|icon('iconify', 'o-icon o-bar-info-icon')|safe }}
@@ -122,11 +123,11 @@
 		<div class="o-bar c-toolbar t-toolbar">
 			<ul class="o-bar-left c-toolbar-left t-toolbar-left">
 				<li class="o-bar-item c-toolbar-item t-toolbar-item">
-					<a class="o-bar-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="{{ lang.return }}">
-						{{ 'mdi:chevron-left'|icon('iconify', 'o-icon o-bar-action-icon c-toolbar-action-icon t-toolbar-action-icon')|safe }}
+					<a class="o-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="{{ lang.return }}">
+						{{ 'mdi:chevron-left'|icon('iconify', 'o-icon o-action-icon c-toolbar-action-icon t-toolbar-action-icon')|safe }}
 					</a>
-					<a class="o-bar-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="{{ lang.forum_watch }}">
-						{{ 'mdi:eye-plus-outline'|icon('iconify', 'o-icon o-bar-action-icon c-toolbar-action-icon t-toolbar-action-icon')|safe }}
+					<a class="o-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="{{ lang.forum_watch }}">
+						{{ 'mdi:eye-plus-outline'|icon('iconify', 'o-icon o-action-icon c-toolbar-action-icon t-toolbar-action-icon')|safe }}
 					</a>
 				</li>
 			</ul>

--- a/all/views/forum.twig
+++ b/all/views/forum.twig
@@ -26,6 +26,7 @@
 		</div>
 	</section>
 
+	{# Subforums #}
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
 			<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
@@ -36,7 +37,7 @@
 				</ul>
 				<ul class="o-bar-right c-topic-header-right t-topic-header-right">
 					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						<a class="o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
 							{{ 'mdi:chevron-up'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
 						</a>
 					</li>
@@ -52,30 +53,28 @@
 		</div>
 	</section>
 
+	{# Toolbar #}
 	<div class="o-container">
 		{% include './includes/forum-tools.twig' %}
 	</div>
 
+	{# Announcements #}
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
-			<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
-				<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">{{ lang.announcements }}</h2>
-					</li>
-				</ul>
-				<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
-							{{ 'mdi:chevron-up'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action c-topic-header-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
-							{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-				</ul>
+			<div class="o-bar" data-toggle-parent="collapse">
+				<div class="o-bar-left">
+					<span class="o-bar-item">
+						<h2 class="o-bar-title" role="heading" aria-level="3">{{ lang.announcements }}</h2>
+					</span>
+				</div>
+				<div class="o-bar-right">
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
+					</a>
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
+						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
+					</a>
+				</div>
 			</div>
 			<ul class="o-list c-topic" role="rowgroup" data-container="collapse">
 				{% for item in announcements %}
@@ -85,72 +84,54 @@
 		</div>
 	</section>
 
+	{# Main Topic List #}
 	<section class="o-container">
 		<div class="c-topic-container t-topic-container">
-			<div class="o-bar c-topic-header" data-toggle-parent="collapse">
-				<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">{{ lang.topics }}</h2>
-					</li>
-				</ul>
-				<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
-							{{ 'mdi:chevron-up'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
-							{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-
-					<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.filter }}">
-							{{ 'mdi:filter-variant'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
+			<div class="o-bar" data-toggle-parent="collapse">
+				<div class="o-bar-left">
+					<span class="o-bar-item">
+						<h2 class="o-bar-title" role="heading" aria-level="3">{{ lang.topics }}</h2>
+					</span>
+				</div>
+				<div class="o-bar-right">
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="{{ lang.expand }}" title="{{ lang.collapse }}">
+						{{ 'mdi:chevron-up'|icon('iconify', 'o-icon')|safe }}
+					</a>
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.mark }}">
+						{{ 'mdi:checkbox-marked-outline'|icon('iconify', 'o-icon')|safe }}
+					</a>
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.filter }}">
+						{{ 'mdi:filter-variant'|icon('iconify', 'o-icon')|safe }}
 						<div class="c-menu-container t-menu-container" data-container="menu">
 							<ul class="c-menu t-menu">
-							{% for item in filters %}
+								{% for item in filters %}
 								<li class="c-menu-item t-menu-item">
 									<a class="c-menu-link t-menu-link" href="#">{{ item }}</a>
 								</li>
-							{% endfor %}
+								{% endfor %}
 							</ul>
 						</div>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.sort }}">
-							{{ 'mdi:sort'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
+					</a>
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="{{ lang.sort }}">
+						{{ 'mdi:sort'|icon('iconify', 'o-icon')|safe }}
 						<div class="c-menu-container t-menu-container" data-container="menu">
 							<ul class="c-menu t-menu">
-							{% for item in sorts %}
+								{% for item in sorts %}
 								<li class="c-menu-item t-menu-item">
 									<a class="c-menu-link t-menu-link" href="#">{{ item }}</a>
 								</li>
-							{% endfor %}
+								{% endfor %}
 							</ul>
 						</div>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="{{ lang.order }}">
-							{{ 'mdi:sort-ascending'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-md-up">
-						<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="{{ lang.sort }}">
-							{{ 'mdi:sort'|icon('iconify', 'o-icon c-topic-header-action-icon t-topic-header-action-icon')|safe }}
-						</a>
-						<div class="c-menu-container t-menu-container" data-container="menu"></div>
-					</li>
-					<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-						<span class="o-bar-info c-topic-header-info t-topic-header-info">
-							{{ 'mdi:file-outline'|icon('iconify', 'o-icon o-bar-info-icon c-topic-info-icon t-topic-info-icon')|safe }}
-							<span class="o-bar-item-text c-topic-header-item-text">{{ topics|length }}</span>
-						</span>
-					</li>
-				</ul>
+					</a>
+					<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="{{ lang.order }}">
+						{{ 'mdi:sort-ascending'|icon('iconify', 'o-icon')|safe }}
+					</a>
+					<span class="o-bar-info">
+						{{ 'mdi:file-outline'|icon('iconify', 'o-icon o-bar-info-icon')|safe }}
+						<span class="o-bar-item-text">{{ topics|length }}</span>
+					</span>
+				</div>
 			</div>
 			<ul class="o-list c-topic" role="rowgroup" data-container="collapse">
 				{% for item in topics | sort(false, false, 'type') | sort(false, false, 'time') %}

--- a/tests/views/forum.html
+++ b/tests/views/forum.html
@@ -536,18 +536,19 @@
 				<section class="o-container">
 					<div class="c-topic-container t-topic-container">
 						<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
-							<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
+							<div class="o-bar-left c-topic-header-left t-topic-header-left">
+								<span class="o-bar-item c-topic-header-item t-topic-header-item">
 									<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">Sub Forums</h2>
-								</li>
-							</ul>
-							<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-							</ul>
+								</span>
+							</div>
+							<div class="o-bar-right c-topic-header-right t-topic-header-right">
+								<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
+								</a>
+								<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
+								</a>
+							</div>
 						</div>
 						<ul class="o-list c-topic t-topic" role="rowgroup" data-container="collapse">
 						</ul>
@@ -640,18 +641,18 @@
 				</div>
 				<section class="o-container">
 					<div class="c-topic-container t-topic-container">
-						<div class="o-bar" data-toggle-parent="collapse">
-							<div class="o-bar-left">
-								<span class="o-bar-item">
-									<h2 class="o-bar-title" role="heading" aria-level="3">Announcements</h2>
+						<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
+							<div class="o-bar-left c-topic-header-left t-topic-header-left">
+								<span class="o-bar-item c-topic-header-item t-topic-header-item">
+									<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">Announcements</h2>
 								</span>
 							</div>
-							<div class="o-bar-right">
-								<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
+							<div class="o-bar-right c-topic-header-right t-topic-header-right">
+								<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
+								<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
 								</a>
 							</div>
 						</div>
@@ -845,18 +846,18 @@
 				</section>
 				<section class="o-container">
 					<div class="c-topic-container t-topic-container">
-						<div class="o-bar" data-toggle-parent="collapse">
-							<div class="o-bar-left">
-								<span class="o-bar-item">
-									<h2 class="o-bar-title" role="heading" aria-level="3">Topics</h2>
+						<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
+							<div class="o-bar-left c-topic-header-left t-topic-header-left">
+								<span class="o-bar-item c-topic-header-item t-topic-header-item">
+									<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">Topics</h2>
 								</span>
 							</div>
-							<div class="o-bar-right">
-								<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
+							<div class="o-bar-right c-topic-header-right t-topic-header-right">
+								<a class="o-bar-item o-action c-topic-header-action c-topic-collapse t-topic-header-action t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
+								<a class="o-bar-item o-action c-topic-header-action c-topic-mark t-topic-header-action t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
 								</a>
 								<span class="o-bar-info c-topic-total t-topic-total">
 									<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-info-icon" data-icon="mdi:file-outline" data-inline="false" aria-hidden="false"></span>
@@ -2057,11 +2058,11 @@
 					<div class="o-bar c-toolbar t-toolbar">
 						<ul class="o-bar-left c-toolbar-left t-toolbar-left">
 							<li class="o-bar-item c-toolbar-item t-toolbar-item">
-								<a class="o-bar-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="Return to ...">
-									<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-action-icon c-toolbar-action-icon t-toolbar-action-icon" data-icon="mdi:chevron-left" data-inline="false" aria-hidden="false"></span>
+								<a class="o-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="Return to ...">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-toolbar-action-icon t-toolbar-action-icon" data-icon="mdi:chevron-left" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="Watch Forum">
-									<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-action-icon c-toolbar-action-icon t-toolbar-action-icon" data-icon="mdi:eye-plus-outline" data-inline="false" aria-hidden="false"></span>
+								<a class="o-action c-toolbar-action t-toolbar-action" href="" data-tooltip="true" title="Watch Forum">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-action-icon c-toolbar-action-icon t-toolbar-action-icon" data-icon="mdi:eye-plus-outline" data-inline="false" aria-hidden="false"></span>
 								</a>
 							</li>
 						</ul>

--- a/tests/views/forum.html
+++ b/tests/views/forum.html
@@ -647,10 +647,10 @@
 								</span>
 							</div>
 							<div class="o-bar-right">
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+								<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
 									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Mark Read">
+								<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
 									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
 								</a>
 							</div>
@@ -852,69 +852,13 @@
 								</span>
 							</div>
 							<div class="o-bar-right">
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+								<a class="o-bar-item o-bar-action c-topic-collapse t-topic-collapse" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
 									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Mark Read">
+								<a class="o-bar-item o-bar-action c-topic-mark t-topic-mark" href="#" data-tooltip="true" title="Mark Read">
 									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
 								</a>
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="Filter">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:filter-variant" data-inline="false" aria-hidden="false"></span>
-									<div class="c-menu-container t-menu-container" data-container="menu">
-										<ul class="c-menu t-menu">
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">All Topics</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">1 Day</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">7 Days</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">2 Weeks</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">1 Month</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">3 Months</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">6 Months</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">1 Year</a>
-											</li>
-										</ul>
-									</div>
-								</a>
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="Sort">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:sort" data-inline="false" aria-hidden="false"></span>
-									<div class="c-menu-container t-menu-container" data-container="menu">
-										<ul class="c-menu t-menu">
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">Author</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">Time</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">Subject</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">Relies</a>
-											</li>
-											<li class="c-menu-item t-menu-item">
-												<a class="c-menu-link t-menu-link" href="#">views</a>
-											</li>
-										</ul>
-									</div>
-								</a>
-								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Order">
-									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:sort-ascending" data-inline="false" aria-hidden="false"></span>
-								</a>
-								<span class="o-bar-info">
+								<span class="o-bar-info c-topic-total t-topic-total">
 									<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-info-icon" data-icon="mdi:file-outline" data-inline="false" aria-hidden="false"></span>
 									<span class="o-bar-item-text">83</span>
 								</span>

--- a/tests/views/forum.html
+++ b/tests/views/forum.html
@@ -543,7 +543,7 @@
 							</ul>
 							<ul class="o-bar-right c-topic-header-right t-topic-header-right">
 								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<a class="o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
 										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
 									</a>
 								</li>
@@ -640,24 +640,20 @@
 				</div>
 				<section class="o-container">
 					<div class="c-topic-container t-topic-container">
-						<div class="o-bar c-topic-header t-topic-header" data-toggle-parent="collapse">
-							<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">Announcements</h2>
-								</li>
-							</ul>
-							<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action c-topic-header-action" href="#" data-tooltip="true" title="Mark Read">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-							</ul>
+						<div class="o-bar" data-toggle-parent="collapse">
+							<div class="o-bar-left">
+								<span class="o-bar-item">
+									<h2 class="o-bar-title" role="heading" aria-level="3">Announcements</h2>
+								</span>
+							</div>
+							<div class="o-bar-right">
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
+								</a>
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Mark Read">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
+								</a>
+							</div>
 						</div>
 						<ul class="o-list c-topic" role="rowgroup" data-container="collapse">
 							<li class="o-list-item c-topic-item t-topic-item" role="row">
@@ -849,27 +845,21 @@
 				</section>
 				<section class="o-container">
 					<div class="c-topic-container t-topic-container">
-						<div class="o-bar c-topic-header" data-toggle-parent="collapse">
-							<ul class="o-bar-left c-topic-header-left t-topic-header-left">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<h2 class="o-bar-title c-topic-header-title t-topic-header-title" role="heading" aria-level="3">Topics</h2>
-								</li>
-							</ul>
-							<ul class="o-bar-right c-topic-header-right t-topic-header-right">
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="Mark Read">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="menu" title="Filter">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:filter-variant" data-inline="false" aria-hidden="false"></span>
-									</a>
+						<div class="o-bar" data-toggle-parent="collapse">
+							<div class="o-bar-left">
+								<span class="o-bar-item">
+									<h2 class="o-bar-title" role="heading" aria-level="3">Topics</h2>
+								</span>
+							</div>
+							<div class="o-bar-right">
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="collapse" data-toggle-tooltip="Expand" title="Collapse">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:chevron-up" data-inline="false" aria-hidden="false"></span>
+								</a>
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Mark Read">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:checkbox-marked-outline" data-inline="false" aria-hidden="false"></span>
+								</a>
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="Filter">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:filter-variant" data-inline="false" aria-hidden="false"></span>
 									<div class="c-menu-container t-menu-container" data-container="menu">
 										<ul class="c-menu t-menu">
 											<li class="c-menu-item t-menu-item">
@@ -898,11 +888,9 @@
 											</li>
 										</ul>
 									</div>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" data-toggle="menu" title="Sort">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:sort" data-inline="false" aria-hidden="false"></span>
-									</a>
+								</a>
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" data-toggle="menu" title="Sort">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:sort" data-inline="false" aria-hidden="false"></span>
 									<div class="c-menu-container t-menu-container" data-container="menu">
 										<ul class="c-menu t-menu">
 											<li class="c-menu-item t-menu-item">
@@ -922,25 +910,15 @@
 											</li>
 										</ul>
 									</div>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="Order">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:sort-ascending" data-inline="false" aria-hidden="false"></span>
-									</a>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-md-up">
-									<a class="o-bar-action c-topic-header-action t-topic-header-action" href="#" data-tooltip="true" title="Sort">
-										<span class="iconify o-icon o-icon-src-mdi o-icon c-topic-header-action-icon t-topic-header-action-icon" data-icon="mdi:sort" data-inline="false" aria-hidden="false"></span>
-									</a>
-									<div class="c-menu-container t-menu-container" data-container="menu"></div>
-								</li>
-								<li class="o-bar-item c-topic-header-item t-topic-header-item u-hidden-sm-down">
-									<span class="o-bar-info c-topic-header-info t-topic-header-info">
-										<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-info-icon c-topic-info-icon t-topic-info-icon" data-icon="mdi:file-outline" data-inline="false" aria-hidden="false"></span>
-										<span class="o-bar-item-text c-topic-header-item-text">83</span>
-									</span>
-								</li>
-							</ul>
+								</a>
+								<a class="o-bar-item o-bar-action" href="#" data-tooltip="true" title="Order">
+									<span class="iconify o-icon o-icon-src-mdi o-icon" data-icon="mdi:sort-ascending" data-inline="false" aria-hidden="false"></span>
+								</a>
+								<span class="o-bar-info">
+									<span class="iconify o-icon o-icon-src-mdi o-icon o-bar-info-icon" data-icon="mdi:file-outline" data-inline="false" aria-hidden="false"></span>
+									<span class="o-bar-item-text">83</span>
+								</span>
+							</div>
 						</div>
 						<ul class="o-list c-topic" role="rowgroup" data-container="collapse">
 							<li class="o-list-item c-topic-item t-topic-item" role="row">


### PR DESCRIPTION
More to follow of topic rework. This is the first of a major overhaul of every component using bars. As well as swapping in css-grid where appropriate